### PR TITLE
Prefix header macro guards with HY_

### DIFF
--- a/src/goal.h
+++ b/src/goal.h
@@ -1,5 +1,5 @@
-#ifndef GOAL_H
-#define GOAL_H
+#ifndef HY_GOAL_H
+#define HY_GOAL_H
 
 // libsolv
 #include "solv/queue.h"

--- a/src/iutil.h
+++ b/src/iutil.h
@@ -1,5 +1,5 @@
-#ifndef IUTIL_H
-#define IUTIL_H
+#ifndef HY_IUTIL_H
+#define HY_IUTIL_H
 
 // libsolv
 #include "solv/queue.h"

--- a/src/package.h
+++ b/src/package.h
@@ -1,5 +1,5 @@
-#ifndef PACKAGE_H
-#define PACKAGE_H
+#ifndef HY_PACKAGE_H
+#define HY_PACKAGE_H
 
 // libsolv
 #include "solv/pool.h"

--- a/src/package_internal.h
+++ b/src/package_internal.h
@@ -1,5 +1,5 @@
-#ifndef PACKAGE_INTERNAL_H
-#define PACKAGE_INTERNAL_H
+#ifndef HY_PACKAGE_INTERNAL_H
+#define HY_PACKAGE_INTERNAL_H
 
 #include "package.h"
 
@@ -18,4 +18,4 @@ static inline Id package_id(HyPackage pkg) { return pkg->id; }
 HyPackage package_from_solvable(Solvable *s);
 HyPackageDelta delta_create(void);
 
-#endif // PACKAGE_INTERNAL_H
+#endif // HY_PACKAGE_INTERNAL_H

--- a/src/packagelist.h
+++ b/src/packagelist.h
@@ -1,5 +1,5 @@
-#ifndef PACKAGELIST_H
-#define PACKAGELIST_H
+#ifndef HY_PACKAGELIST_H
+#define HY_PACKAGELIST_H
 
 // libsolv
 #include "solv/queue.h"
@@ -20,4 +20,4 @@ void hy_packagelist_push(HyPackageList plist, HyPackage pkg);
 #define FOR_PACKAGELIST(pkg, pkglist, i)						\
     for (i = 0; (pkg = hy_packagelist_get(pkglist, i++)) != NULL; )
 
-#endif // PACKAGELIST_H
+#endif // HY_PACKAGELIST_H

--- a/src/query.h
+++ b/src/query.h
@@ -1,5 +1,5 @@
-#ifndef QUERY_H
-#define QUERY_H
+#ifndef HY_QUERY_H
+#define HY_QUERY_H
 
 // hawkey
 #include "packagelist.h"
@@ -64,4 +64,4 @@ void hy_query_filter_obsoleting(HyQuery q, int val);
 
 HyPackageList hy_query_run(HyQuery q);
 
-#endif // QUERY_H
+#endif // HY_QUERY_H

--- a/src/query_internal.h
+++ b/src/query_internal.h
@@ -1,8 +1,8 @@
-#ifndef QUERY_INTERNAL_H
-#define QUERY_INTERNAL_H
+#ifndef HY_QUERY_INTERNAL_H
+#define HY_QUERY_INTERNAL_H
 
 #include "query.h"
 
 int query2job(const HyQuery q, Queue *job, int solver_action);
 
-#endif // QUERY_INTERNAL_H
+#endif // HY_QUERY_INTERNAL_H

--- a/src/repo.h
+++ b/src/repo.h
@@ -1,5 +1,5 @@
-#ifndef REPO_H
-#define REPO_H
+#ifndef HY_REPO_H
+#define HY_REPO_H
 
 #include "types.h"
 
@@ -16,4 +16,4 @@ void hy_repo_set_string(HyRepo repo, enum _hy_repo_param_e which, const char *st
 const char *hy_repo_get_string(HyRepo repo, enum _hy_repo_param_e which);
 void hy_repo_free(HyRepo repo);
 
-#endif // REPO_H
+#endif // HY_REPO_H

--- a/src/repo_internal.h
+++ b/src/repo_internal.h
@@ -1,5 +1,5 @@
-#ifndef REPO_INTERNAL_H
-#define REPO_INTERNAL_H
+#ifndef HY_REPO_INTERNAL_H
+#define HY_REPO_INTERNAL_H
 
 // libsolv
 #include <solv/pooltypes.h>
@@ -44,4 +44,4 @@ int hy_repo_transition(HyRepo repo, enum _hy_repo_state new_state);
 Id repo_get_repodata(HyRepo repo, enum _hy_repo_repodata which);
 void repo_set_repodata(HyRepo repo, enum _hy_repo_repodata which, Id repodata);
 
-#endif // REPO_INTERNAL_H
+#endif // HY_REPO_INTERNAL_H

--- a/src/sack.h
+++ b/src/sack.h
@@ -1,5 +1,5 @@
-#ifndef SACK_H
-#define SACK_H
+#ifndef HY_SACK_H
+#define HY_SACK_H
 
 // libsolv
 #include "solv/pool.h"
@@ -29,4 +29,4 @@ int hy_sack_write_all_repos(HySack sack);
 int hy_sack_write_filelists(HySack sack);
 int hy_sack_write_presto(HySack sack);
 
-#endif // SACK_H
+#endif // HY_SACK_H

--- a/src/sack_internal.h
+++ b/src/sack_internal.h
@@ -1,5 +1,5 @@
-#ifndef SACK_INTERNAL_H
-#define SACK_INTERNAL_H
+#ifndef HY_SACK_INTERNAL_H
+#define HY_SACK_INTERNAL_H
 
 #include <stdio.h>
 
@@ -19,4 +19,4 @@ void sack_log(HySack sack, int level, const char *format, ...);
 void sack_same_names(HySack sack, Id name, Id arch, Queue *same);
 static inline Pool *sack_pool(HySack sack) { return sack->pool; }
 
-#endif // SACK_INTERNAL_H
+#endif // HY_SACK_INTERNAL_H


### PR DESCRIPTION
Currently hawkey ueses #ifndef QUERY_H, REPO_H etc in its public
headers but those names are just too general up and down the depchain
between zif, hawkey, libsolv and rpm-libs.
This patch adds an "HY_" prefix to all macro guards including those of
non-public headers like util.h and XXX_internal.h.
