### PR TITLE
Header cleanups

### DIFF
--- a/src/goal.h
+++ b/src/goal.h
@@ -1,6 +1,10 @@
 #ifndef HY_GOAL_H
 #define HY_GOAL_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* libsolv */
 #include "solv/queue.h"
 #include "solv/transaction.h"
@@ -44,5 +48,9 @@ HyPackageList hy_goal_list_installs(HyGoal goal);
 HyPackageList hy_goal_list_upgrades(HyGoal goal);
 HyPackageList hy_goal_list_downgrades(HyGoal goal);
 HyPackage hy_goal_package_obsoletes(HyGoal goal, HyPackage pkg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/package.h
+++ b/src/package.h
@@ -1,6 +1,10 @@
 #ifndef HY_PACKAGE_H
 #define HY_PACKAGE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* libsolv */
 #include "solv/pool.h"
 #include "solv/solvable.h"
@@ -33,5 +37,9 @@ int hy_package_get_size(HyPackage pkg);
 HyPackageDelta hy_package_get_delta_from_evr(HyPackage pkg, const char *from_evr);
 const char *hy_packagedelta_get_location(HyPackageDelta delta);
 void hy_packagedelta_free(HyPackageDelta delta);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/packagelist.h
+++ b/src/packagelist.h
@@ -1,6 +1,10 @@
 #ifndef HY_PACKAGELIST_H
 #define HY_PACKAGELIST_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* libsolv */
 #include "solv/queue.h"
 
@@ -19,5 +23,9 @@ void hy_packagelist_push(HyPackageList plist, HyPackage pkg);
 
 #define FOR_PACKAGELIST(pkg, pkglist, i)						\
     for (i = 0; (pkg = hy_packagelist_get(pkglist, i++)) != NULL; )
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* HY_PACKAGELIST_H */

--- a/src/query.h
+++ b/src/query.h
@@ -1,6 +1,10 @@
 #ifndef HY_QUERY_H
 #define HY_QUERY_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* hawkey */
 #include "packagelist.h"
 #include "sack.h"
@@ -63,5 +67,9 @@ void hy_query_filter_latest(HyQuery q, int val);
 void hy_query_filter_obsoleting(HyQuery q, int val);
 
 HyPackageList hy_query_run(HyQuery q);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* HY_QUERY_H */

--- a/src/repo.h
+++ b/src/repo.h
@@ -3,6 +3,10 @@
 
 #include "types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum _hy_repo_param_e {
     HY_REPO_NAME,
     HY_REPO_MD_FN,
@@ -15,5 +19,9 @@ HyRepo hy_repo_create(void);
 void hy_repo_set_string(HyRepo repo, enum _hy_repo_param_e which, const char *str_val);
 const char *hy_repo_get_string(HyRepo repo, enum _hy_repo_param_e which);
 void hy_repo_free(HyRepo repo);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* HY_REPO_H */

--- a/src/sack.h
+++ b/src/sack.h
@@ -9,6 +9,10 @@
 #include "package.h"
 #include "types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define HY_SYSTEM_REPO_NAME "@System"
 #define HY_SYSTEM_RPMDB "/var/lib/rpm/Packages"
 #define HY_CMDLINE_REPO_NAME "@commandline"
@@ -28,5 +32,9 @@ int hy_sack_load_presto(HySack sack);
 int hy_sack_write_all_repos(HySack sack);
 int hy_sack_write_filelists(HySack sack);
 int hy_sack_write_presto(HySack sack);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* HY_SACK_H */

--- a/src/types.h
+++ b/src/types.h
@@ -1,6 +1,10 @@
 #ifndef HY_TYPES_H
 #define HY_TYPES_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct _HyRepo * HyRepo;
 typedef struct _HyGoal * HyGoal;
 typedef struct _HyPackage * HyPackage;
@@ -11,5 +15,9 @@ typedef struct _HyQuery * HyQuery;
 typedef struct _HySack * HySack;
 
 typedef const unsigned char HyChecksum;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* HY_TYPES_H */

--- a/src/util.h
+++ b/src/util.h
@@ -1,8 +1,16 @@
 #ifndef HY_UTIL_H
 #define HY_UTIL_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void *hy_free(void *mem);
 const char *chksum_name(int chksum_type);
 char *chksum_str(const unsigned char *chksum, int type);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* HY_UTIL_H */


### PR DESCRIPTION
This branch contains trivial cleanups to the hawkey public headers:
Use C89 style comments in public headers: /\* */ instead of //
Make public headers usable with C++ through extern "C"

Patches were compile tested.
