### PR TITLE
Disable color-processing for obsoletes (RhBug:970211)

### DIFF
--- a/src/sack.c
+++ b/src/sack.c
@@ -415,6 +415,7 @@ hy_sack_create(const char *cache_path, const char *arch, const char *rootdir,
     Pool *pool = pool_create();
 
     pool_set_rootdir(pool, rootdir);
+    pool_set_flag(pool, POOL_FLAG_OBSOLETEUSESCOLORS, 0);
     sack->pool = pool;
 
     if (cache_path != NULL) {


### PR DESCRIPTION
This makes libsolv agree with rpm >= 4.10 behavior of obsoletes,
fixing the issue of libsolv not noticing an obsoleting package
(of different architecture) has already been installed.
