### PR TITLE
python3: Don't return checksum as bytes.

### DIFF
--- a/src/python/package-py.c
+++ b/src/python/package-py.c
@@ -274,13 +274,7 @@ get_chksum(_PackageObject *self, void *closure)
 
     PyObject *res;
     int checksum_length = checksum_type2length(type);
-
-#if PY_MAJOR_VERSION < 3
     res = Py_BuildValue("is#", type, cs, checksum_length);
-#else
-    res = Py_BuildValue("iy#", type, cs, checksum_length);
-#endif
-
     return res;
 }
 

--- a/src/python/packagedelta-py.c
+++ b/src/python/packagedelta-py.c
@@ -90,13 +90,7 @@ get_chksum(_PackageDeltaObject *self, void *closure)
 
     PyObject *res;
     int checksum_length = checksum_type2length(type);
-
-#if PY_MAJOR_VERSION < 3
     res = Py_BuildValue("is#", type, cs, checksum_length);
-#else
-    res = Py_BuildValue("iy#", type, cs, checksum_length);
-#endif
-
     return res;
 }
 


### PR DESCRIPTION
Have no idea why the #if was there.. an optimisation, perhaps?  python3-librepo is not happy with PackageTarget(csum=<a byte string>)..
