### PR TITLE
sack: Also look in /usr/share/rpm for Packages

### DIFF
--- a/src/sack.c
+++ b/src/sack.c
@@ -67,9 +67,13 @@ enum _hy_sack_cpu_flags {
 static int
 current_rpmdb_checksum(Pool *pool, unsigned char csout[CHKSUM_BYTES])
 {
-    const char *fn = pool_prepend_rootdir_tmp(pool, HY_SYSTEM_RPMDB);
+    const char *fn = pool_prepend_rootdir_tmp(pool, HY_SYSTEM_RO_RPMDB);
     FILE *fp_rpmdb = fopen(fn, "r");
     int ret = 0;
+
+
+    if (!fp_rpmdb)
+      fn = pool_prepend_rootdir_tmp (pool, HY_SYSTEM_RPMDB);
 
     if (!fp_rpmdb || checksum_stat(csout, fp_rpmdb))
 	ret = 1;

--- a/src/types.h
+++ b/src/types.h
@@ -49,6 +49,7 @@ typedef int (*hy_solution_callback)(HyGoal goal, void *callback_data);
 
 #define HY_SYSTEM_REPO_NAME "@System"
 #define HY_SYSTEM_RPMDB "/var/lib/rpm/Packages"
+#define HY_SYSTEM_RO_RPMDB "/usr/share/rpm/Packages"
 #define HY_CMDLINE_REPO_NAME "@commandline"
 #define HY_EXT_FILENAMES "-filenames"
 #define HY_EXT_UPDATEINFO "-updateinfo"


### PR DESCRIPTION
In the rpm-ostree model, the RPM database lives in /usr/share/rpm, and
is immutable.  Let's look there first, and then fall back to the old
mutable database.
