### PR TITLE
sack: Also look in /usr/share/rpm for Packages

### DIFF
--- a/src/sack.c
+++ b/src/sack.c
@@ -67,9 +67,19 @@ enum _hy_sack_cpu_flags {
 static int
 current_rpmdb_checksum(Pool *pool, unsigned char csout[CHKSUM_BYTES])
 {
-    const char *fn = pool_prepend_rootdir_tmp(pool, HY_SYSTEM_RPMDB);
-    FILE *fp_rpmdb = fopen(fn, "r");
+    const char *rpmdb_prefix_paths[] = { "/var/lib/rpm/Packages",
+					 "/usr/share/rpm/Packages" };
+    unsigned int i;
+    const char *fn;
+    FILE *fp_rpmdb = NULL;
     int ret = 0;
+
+    for (i = 0; i < sizeof(rpmdb_prefix_paths)/sizeof(*rpmdb_prefix_paths); i++) {
+	fn = pool_prepend_rootdir_tmp(pool, rpmdb_prefix_paths[i]);
+	fp_rpmdb = fopen(fn, "r");
+	if (fp_rpmdb)
+	    break;
+    }
 
     if (!fp_rpmdb || checksum_stat(csout, fp_rpmdb))
 	ret = 1;

--- a/src/types.h
+++ b/src/types.h
@@ -48,7 +48,6 @@ typedef const unsigned char HyChecksum;
 typedef int (*hy_solution_callback)(HyGoal goal, void *callback_data);
 
 #define HY_SYSTEM_REPO_NAME "@System"
-#define HY_SYSTEM_RPMDB "/var/lib/rpm/Packages"
 #define HY_CMDLINE_REPO_NAME "@commandline"
 #define HY_EXT_FILENAMES "-filenames"
 #define HY_EXT_UPDATEINFO "-updateinfo"


### PR DESCRIPTION
Followup on https://github.com/akozumpl/hawkey/pull/47

In the rpm-ostree model, the RPM database lives in /usr/share/rpm, and
is immutable.  Let's look there first, and then fall back to the old
mutable database.

This removes the #define from the public API, as it's not useful to
external consumers.
