### PR TITLE
implement updateinfo caching

### DIFF
--- a/src/repo_internal.h
+++ b/src/repo_internal.h
@@ -54,6 +54,10 @@ struct _HyRepo {
     unsigned char checksum[CHKSUM_BYTES];
     Repo *libsolv_repo;
     int load_flags;
+    /* the following three elements are needed for repo rewriting */
+    int main_nsolvables;
+    int main_nrepodata;
+    int main_end;
 };
 
 enum _hy_repo_repodata {


### PR DESCRIPTION
Things are a bit tricky, as the updateinfo is not an extension
for existing solvables, but contains its own set of solvables.
libsolv should offer more support for this kind of setup.
