### PR TITLE
add includepkgs api

### DIFF
--- a/src/goal.c
+++ b/src/goal.c
@@ -299,6 +299,12 @@ construct_job(HyGoal goal, int flags)
 	    if (MAPTST(sack->pkg_excludes, i))
 		queue_push2(job, SOLVER_SOLVABLE|SOLVER_LOCK, i);
 
+    /* apply includepkg white list */
+    if (sack->cont_includepkgs)
+	for (int i = 0; i < pool->nsolvables; ++i)
+	    if ((MAPTST(sack->fin_includepkgs, i)))
+		queue_push2(job, SOLVER_SOLVABLE|SOLVER_LOCK, i);
+
     return job;
 }
 

--- a/src/python/sack-py.c
+++ b/src/python/sack-py.c
@@ -334,8 +334,34 @@ add_excludes(_SackObject *self, PyObject *seq)
     HySack sack = self->sack;
     HyPackageSet pset = pyseq_to_packageset(seq, sack);
     hy_sack_add_excludes(sack, pset);
+
     hy_packageset_free(pset);
     Py_RETURN_NONE;
+}
+
+static PyObject *
+add_includepkgs(_SackObject *self, PyObject *seq)
+{
+    if (!PySequence_Check(seq)) {
+	PyErr_SetString(PyExc_TypeError, "Expected a sequence.");
+	return NULL;
+    }
+    HySack sack = self->sack;
+
+    HyPackageSet pset = pyseq_to_packageset(seq, sack);
+    hy_sack_add_includepkgs(sack, pset);
+
+    hy_packageset_free(pset);
+    Py_RETURN_NONE;
+}
+
+static PyObject *
+eval_includepkgs(_SackObject *self)
+{
+    HySack sack = self->sack;
+    hy_sack_eval_includepkgs(sack);
+    Py_RETURN_NONE;
+
 }
 
 static PyObject *
@@ -450,6 +476,10 @@ PyMethodDef sack_methods[] = {
     {"add_cmdline_package", (PyCFunction)add_cmdline_package, METH_O,
      NULL},
     {"add_excludes", (PyCFunction)add_excludes, METH_O,
+     NULL},
+    {"add_includepkgs", (PyCFunction)add_includepkgs, METH_O,
+     NULL},
+    {"eval_includepkgs", (PyCFunction)eval_includepkgs, METH_O,
      NULL},
     {"disable_repo", (PyCFunction)disable_repo, METH_O,
      NULL},

--- a/src/query.c
+++ b/src/query.c
@@ -739,6 +739,9 @@ compute(HyQuery q)
     if (q->sack->excludes && !(q->flags & HY_IGNORE_EXCLUDES))
 	map_subtract(q->result, q->sack->excludes);
 
+    if (q->sack->cont_includepkgs)
+	map_subtract(q->result, q->sack->fin_includepkgs);
+
     // make sure the odd bits are cleared:
     unsigned total_bits = q->result->size << 3;
     for (int i = pool->nsolvables; i < total_bits; ++i)

--- a/src/sack.c
+++ b/src/sack.c
@@ -646,6 +646,7 @@ hy_sack_create(const char *cache_path, const char *arch, const char *rootdir,
     sack->pool = pool;
     sack->running_kernel = -1;
     sack->running_kernel_fn = running_kernel;
+    sack->cont_includepkgs = 0;
 
     if (cache_path != NULL) {
 	sack->cache_dir = solv_strdup(cache_path);
@@ -708,6 +709,8 @@ hy_sack_free(HySack sack)
     free_map_fully(sack->excludes);
     free_map_fully(sack->pkg_excludes);
     free_map_fully(sack->repo_excludes);
+    free_map_fully(sack->includepkgs);
+    free_map_fully(sack->fin_includepkgs);
     pool_free(sack->pool);
     solv_free(sack);
 }
@@ -846,6 +849,69 @@ hy_sack_set_excludes(HySack sack, HyPackageSet pset)
 	map_init_clone(sack->pkg_excludes, nexcl);
     }
     recompute_excludes(sack);
+}
+
+/* function adds a packageset pset to includepackgs list to sack.
+ * There is necessary to use hy_sack_eval_includepkgs function when
+ * includepkgs list is complete to fill fin_includepkgs structure
+ */
+void
+hy_sack_add_includepkgs(HySack sack, HyPackageSet pset)
+{
+    Pool *pool = sack_pool(sack);
+    Map *incl = sack->includepkgs;
+    Map *nincl = packageset_get_map(pset);
+
+    if (incl == NULL) {
+	incl = solv_calloc(1, sizeof(Map));
+	map_init(incl, pool->nsolvables);
+	sack->includepkgs = incl;
+    }
+    assert(incl->size >= nincl->size);
+    map_or(incl, nincl);
+}
+
+void
+hy_sack_set_includepkgs(HySack sack, HyPackageSet pset)
+{
+    sack->includepkgs = free_map_fully(sack->includepkgs);
+    if (pset) {
+        Map *nincl = packageset_get_map(pset);
+	sack->includepkgs = solv_calloc(1, sizeof(Map));
+	map_init_clone(sack->includepkgs, nincl);
+    }
+}
+
+/* TODO: move to libsepol library */
+void
+map_neg(Map *t, Map *s)
+{
+    unsigned char *ti, *si, *end;
+    ti = t->map;
+    si = s->map;
+    end = ti + (t->size < s->size ? t->size : s->size);
+    while (ti < end)
+	*ti++ = 255 - *si++;
+}
+
+/* fill fin_includepkgs structure by the negation of includepkgs
+ */
+void
+hy_sack_eval_includepkgs(HySack sack)
+{
+    Map *fi;
+
+    if ((sack) && (sack->includepkgs)) {
+	sack->cont_includepkgs = 1;
+
+	if (sack->fin_includepkgs)
+	    free_map_fully(sack->fin_includepkgs);
+
+	fi = solv_calloc(1, sizeof(Map));
+	map_init(fi, (sack->includepkgs->size * 8)-7);
+	map_neg(fi, sack->includepkgs);
+	sack->fin_includepkgs = fi;
+     }
 }
 
 int

--- a/src/sack.h
+++ b/src/sack.h
@@ -53,6 +53,9 @@ HyPackage hy_sack_add_cmdline_package(HySack sack, const char *fn);
 int hy_sack_count(HySack sack);
 void hy_sack_add_excludes(HySack sack, HyPackageSet pset);
 void hy_sack_set_excludes(HySack sack, HyPackageSet pset);
+void hy_sack_add_includepkgs(HySack sack, HyPackageSet pset);
+void hy_sack_set_includepkgs(HySack sack, HyPackageSet pset);
+void hy_sack_eval_includepkgs(HySack sack);
 int hy_sack_repo_enabled(HySack sack, const char *reponame, int enabled);
 
 /**

--- a/src/sack_internal.h
+++ b/src/sack_internal.h
@@ -43,6 +43,11 @@ struct _HySack {
     Map *pkg_excludes;
     Map *repo_excludes;
     Map *excludes;
+    Map *includepkgs;		/* list of all whitelisted packages - when
+				 * the list is complete it is used to fill
+				 * includepkgs and cont_includepkgs variables */
+    int cont_includepkgs;	/* includepkgs procesed */
+    Map *fin_includepkgs;	/* pkgs white list (dnf.conf includepkgs option) */
 };
 
 void sack_make_provides_ready(HySack sack);


### PR DESCRIPTION
Add api to deal with includepkgs tag:

struct _HySack {
...
Map _includepkgs;       /_ list of all whitelisted packages - when
                 \* the list is complete it is used to fill
                 \* includepkgs and cont_includepkgs variables _/
int cont_includepkgs;       /_ includepkgs procesed _/
Map *fin_includepkgs;       /_ pkgs white list (dnf.conf includepkgs option) */
}

/\* function adds a packageset pset to includepackgs list to sack.
- There is necessary to use hy_sack_eval_includepkgs function when
- includepkgs list is complete to fill fin_includepkgs structure _/
  void hy_sack_add_includepkgs(HySack sack, HyPackageSet pset);
  void hy_sack_set_includepkgs(HySack sack, HyPackageSet pset);
  /_ fill fin_includepkgs structure by the negation of includepkgs */
  void hy_sack_eval_includepkgs(HySack sack);

Signed-off-by: Ivana Hutarova Varekova varekova@redhat.com
