### PR TITLE
Match ARM_HFP against vfp instead of vpfv3

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -50,7 +50,7 @@ parse_cpu_flags(int *flags, const char *section)
 	while (tok) {
 	    if (!strcmp(tok, "neon"))
 		*flags |= ARM_NEON;
-	    else if (!strcmp(tok, "vfpv3"))
+	    else if (!strcmp(tok, "vfp"))
 		*flags |= ARM_HFP;
 	    tok = strtok_r(NULL, " ", &saveptr);
 	}


### PR DESCRIPTION
This change allows also armv6hl to be identified as hardfp.
Without this change dnf will not mirror yum in its identification of arch.