### PR TITLE
Add support for armv6hl

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,6 @@
 Ales Kozumplik <ales@redhat.com>
 Jan Silhan <jsilhan@redhat.com>
+Peter Hjalmarsson <kanelxake@gmail.com>
 Radek Holy <rholy@redhat.com>
 Richard Hughes <richard@hughsie.com>
 Scott Tsai <scottt.tw@gmail.com>


### PR DESCRIPTION
This patch uses the vfp extension on armv6l to identify if a hardfp target (armv6hl) is valid.
Tested on my RaspberryPI, works well.