### PR TITLE
sack: calls reinitiate provides after changing considered map (RhBug:1099342)

### DIFF
--- a/doc/reference-py-sack.rst
+++ b/doc/reference-py-sack.rst
@@ -16,7 +16,7 @@
   Red Hat, Inc.
 
 *******************************************
-``Sack``---The fundamental hawkey structure
+Sack---The fundamental hawkey structure
 *******************************************
 
 .. class:: hawkey.Sack

--- a/doc/reference-py-sack.rst
+++ b/doc/reference-py-sack.rst
@@ -101,6 +101,14 @@
     Enable the repository identified by a string *name*. Packages in that
     repository can be fetched by Queries or Selectors.
 
+  .. warning:: Execution of :meth:`add_excludes`, :meth:`add_includes`,
+               :meth:`disable_repo` or :meth:`enable_repo` methods could cause
+               inconsistent results in previously evaluated :class:`.Query`,
+               :class:`.Selector` or :class:`.Goal`. The rule of thumb is
+               to exclude/include packages, enable/disable repos at first and
+               then do actual computing using :class:`.Query`, :class:`.Selector`
+               or :class:`.Goal`.
+
   .. method:: evr_cmp(evr1, evr2)
 
     Compare two EVR strings and return a negative integer if *evr1* < *evr2*,

--- a/src/goal.c
+++ b/src/goal.c
@@ -253,6 +253,9 @@ solve(HyGoal goal, Queue *job, int flags, hy_solution_callback user_cb,
     HySack sack = goal->sack;
     struct _SolutionCallback cb_tuple;
 
+    /* apply the excludes */
+    sack_recompute_considered(sack);
+
     repo_internalize_all_trigger(sack_pool(sack));
     sack_make_provides_ready(sack);
     if (goal->trans) {
@@ -302,9 +305,6 @@ construct_job(HyGoal goal, int flags)
 
     if (flags & HY_VERIFY)
         queue_push2(job, SOLVER_VERIFY|SOLVER_SOLVABLE_ALL, 0);
-
-    /* apply the excludes */
-    sack_recompute_considered(sack);
 
     return job;
 }
@@ -556,6 +556,7 @@ sltr2job(const HySelector sltr, Queue *job, int solver_action)
 	goto finish;
     }
 
+    sack_recompute_considered(sack);
     sack_make_provides_ready(sack);
     ret = filter_name2job(sack, sltr->f_name, &job_sltr);
     if (ret)

--- a/src/sack.c
+++ b/src/sack.c
@@ -142,6 +142,7 @@ sack_recompute_considered(HySack sack)
 	map_subtract(pool->considered, sack->pkg_excludes);
     if (sack->pkg_includes)
 	map_and(pool->considered, sack->pkg_includes);
+    pool_createwhatprovides(sack->pool);
     sack->considered_uptodate = 1;
 }
 

--- a/tests/test_goal.c
+++ b/tests/test_goal.c
@@ -805,7 +805,7 @@ START_TEST(test_goal_describe_problem_excludes)
     fail_unless(hy_goal_count_problems(goal) > 0);
 
     char *problem = hy_goal_describe_problem(goal, 0);
-    ck_assert_str_eq(problem, "package semolina-2-0.x86_64 is not installable");
+    ck_assert_str_eq(problem, "package semolina does not exist");
     hy_free(problem);
 
     hy_goal_free(goal);
@@ -824,6 +824,29 @@ START_TEST(test_goal_distupgrade_all)
     hy_packagelist_free(plist);
 
     plist = hy_goal_list_downgrades(goal);
+    fail_unless(hy_packagelist_count(plist) == 1);
+    assert_nevra_eq(hy_packagelist_get(plist, 0), "baby-6:4.9-3.x86_64");
+    hy_packagelist_free(plist);
+    hy_goal_free(goal);
+}
+END_TEST
+
+START_TEST(test_goal_distupgrade_all_excludes)
+{
+    HyQuery q = hy_query_create_flags(test_globals.sack, HY_IGNORE_EXCLUDES);
+    hy_query_filter(q, HY_PKG_NAME, HY_EQ, "flying");
+    HyPackageSet pset = hy_query_run_set(q);
+    hy_sack_add_excludes(test_globals.sack, pset);
+    hy_packageset_free(pset);
+    hy_query_free(q);
+
+    HyGoal goal = hy_goal_create(test_globals.sack);
+    fail_if(hy_goal_distupgrade_all(goal));
+    fail_if(hy_goal_run(goal));
+
+    assert_iueo(goal, 0, 0, 0, 0);
+
+    HyPackageList plist = hy_goal_list_downgrades(goal);
     fail_unless(hy_packagelist_count(plist) == 1);
     assert_nevra_eq(hy_packagelist_get(plist, 0), "baby-6:4.9-3.x86_64");
     hy_packagelist_free(plist);
@@ -1228,6 +1251,7 @@ goal_suite(void)
     tcase_add_test(tc, test_goal_install_selector_file);
     tcase_add_test(tc, test_goal_rerun);
     tcase_add_test(tc, test_goal_unneeded);
+    tcase_add_test(tc, test_goal_distupgrade_all_excludes);
     suite_add_tcase(s, tc);
 
     tc = tcase_create("Greedy");

--- a/tests/test_package.c
+++ b/tests/test_package.c
@@ -192,8 +192,6 @@ START_TEST(test_get_files)
 {
     HySack sack = test_globals.sack;
 
-    //sack_make_provides_ready(sack);
-
     HyPackage pkg = by_name(sack, "tour");
     HyStringArray files = hy_package_get_files(pkg);
     char *f;


### PR DESCRIPTION
Thanks for the tip for https://bugzilla.redhat.com/show_bug.cgi?id=1099342, @mlschroe . `pool_createwhatprovides(sack->pool);` did the job. 
Should we call on pool->considered change again:
```
pool_addfileprovides_queue(sack->pool, &addedfileprovides,
				   &addedfileprovides_inst);
rewrite_repos(sack, &addedfileprovides, &addedfileprovides_inst);
pool_createwhatprovides(sack->pool);
```
or just `pool_createwhatprovides(sack->pool);` is enough?