### PR TITLE
Package.files returns list of Unicode objects

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -616,3 +616,16 @@ Sack method `load_yum_repo` has been renamed to :meth:`.Sack.load_repo`
 Hawkey is package manager agnostic and the ``yum`` phrase could be misleading.
 
 The method will be dropped after 2015-10-27 AND no sooner than in 0.5.8.
+
+
+Changes in 0.5.7
+================
+
+Python bindings
+---------------
+
+Package: file attribute is represented by list of Unicode objects
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Sack: `list_arches` method returns list of Unicode objects
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/python/iutil-py.c
+++ b/src/python/iutil-py.c
@@ -255,7 +255,7 @@ strlist_to_pylist(const char **slist)
 	return NULL;
 
     for (const char **iter = slist; *iter; ++iter) {
-	PyObject *str = PyString_FromString(*iter);
+	PyObject *str = PyUnicode_FromString(*iter);
 	if (str == NULL)
 	    goto err;
 	int rc = PyList_Append(list, str);


### PR DESCRIPTION
It's still better to do that in Hawkey. The rest of attributes are already Unicoded.
