### PR TITLE
subject: Remove internal header includes from public header

### DIFF
--- a/src/subject.c
+++ b/src/subject.c
@@ -24,6 +24,8 @@
 #include "sack_internal.h"
 #include "subject.h"
 #include "subject_internal.h"
+#include "nevra.h"
+#include "nevra_internal.h"
 #include "types.h"
 
 // most specific to least

--- a/src/subject.h
+++ b/src/subject.h
@@ -25,8 +25,6 @@
 #include <solv/util.h>
 #include "types.h"
 #include "nevra.h"
-#include "nevra_internal.h"
-#include "iutil.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Including `iutil.h` and `nevra_internal.h` makes the header file
unusable from other C projects such as libhif.