### PR TITLE
sack: Remove incorrect assertion

### DIFF
--- a/src/sack.c
+++ b/src/sack.c
@@ -835,7 +835,6 @@ hy_sack_add_excludes(HySack sack, HyPackageSet pset)
 	map_init(excl, pool->nsolvables);
 	sack->pkg_excludes = excl;
     }
-    assert(excl->size >= nexcl->size);
     map_or(excl, nexcl);
     sack->considered_uptodate = 0;
 }


### PR DESCRIPTION
TL;DR: The libsolv `map_and` expands the first argument as needed,
so this assertion is incorrect.

Longer story:

I kept having rpm-ostree crash recently inside `hy_sack_add_excludes`
when running Hawkey from git master.

It turns out that I'd changed my local build scripts to use the CMake
`Debug` target (instead of the RPM spec which uses `RelWithDebInfo`)
so I could actually use gdb with unoptimized builds.

One of the futher things `RelWithDebInfo` does over `Debug` is
`#define NDEBUG` which *turns off assert()`*. Personally, I think this
is deeply evil, and maybe we can consider switching to `g_assert`.

See also http://stackoverflow.com/questions/22140520/how-to-enable-assert-in-cmake-release-mode