### PR TITLE
subject: Fix compiler warning introduced by previous commit

### DIFF
--- a/src/subject.c
+++ b/src/subject.c
@@ -25,6 +25,7 @@
 #include "subject.h"
 #include "subject_internal.h"
 #include "nevra.h"
+#include "iutil.h"
 #include "nevra_internal.h"
 #include "types.h"
 


### PR DESCRIPTION
Sorry about that.  I need to figure out how to configure CMake to use
`-Werror=implicit-function-declaration` by default.