### PR TITLE
don't require python3 in rhel

### DIFF
--- a/hawkey.spec
+++ b/hawkey.spec
@@ -3,6 +3,8 @@
 %if 0%{?rhel} != 0 && 0%{?rhel} <= 7
 # Do not build bindings for python3 for RHEL <= 7
 %bcond_with python3
+%else
+%bcond_without python3
 %endif
 
 Name:		hawkey


### PR DESCRIPTION
@cgwalters , I haven't noticed in your mail that you wanted python3 exclude patch in **dist-git**. That would break our tito release workflow. We'd better add it into upstream. Is this ok?