### PR TITLE
query: return empty query if we can't make reldep (RhBug:1244544)

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -981,7 +981,7 @@ hy_query_filter(HyQuery q, int keyname, int cmp_type, const char *match)
 	HyReldep reldep = reldep_from_str(sack, match);
 
 	if (reldep == NULL)
-	    return HY_E_QUERY;
+	    return hy_query_filter_empty(q);
 	int ret = hy_query_filter_reldep(q, keyname, reldep);
 	hy_reldep_free(reldep);
 	return ret;

--- a/tests/python/tests/test_query.py
+++ b/tests/python/tests/test_query.py
@@ -183,6 +183,9 @@ class TestQuery(base.TestCase):
         self.assertRaises(hawkey.QueryException, q.filter,
                           provides__gt=requires[0])
 
+        q = hawkey.Query(self.sack).filter(provides="thisisnotgoingtoexist")
+        self.assertLength(q.run(), 0)
+
     def test_reldep_list(self):
         self.sack.load_test_repo("updates", "updates.repo")
         fool = base.by_name_repo(self.sack, "fool", "updates")

--- a/tests/test_query.c
+++ b/tests/test_query.c
@@ -655,6 +655,10 @@ START_TEST(test_query_provides_str)
     ck_assert_int_eq(query_count_results(q), 2);
     hy_query_free(q);
 
+    q = hy_query_create(test_globals.sack);
+    hy_query_filter(q, HY_PKG_PROVIDES, HY_EQ, "thisisnotgoingtoexist");
+    ck_assert_int_eq(query_count_results(q), 0);
+    hy_query_free(q);
 }
 END_TEST
 


### PR DESCRIPTION
reldep_from_str(sack, match) will return NULL if match (our search str)
is not found in sack. Let's don't crash and just return empty query.

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1244544
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>