### PR TITLE
Add support for little endian MIPS

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -141,6 +141,12 @@ hy_detect_arch(char **arch)
 	else if (flags & ARM_VFP3)
 	    strcpy(un.machine, "armv7hl");
     }
+#ifdef __MIPSEL__
+    if (!strcmp(un.machine, "mips"))
+	strcpy(un.machine, "mipsel");
+    else if (!strcmp(un.machine, "mips64"))
+	strcpy(un.machine, "mips64el");
+#endif
     *arch = solv_strdup(un.machine);
     return 0;
 }


### PR DESCRIPTION
Signed-off-by: Michal Toman <mtoman@fedoraproject.org>

Hawkey uses uname to determine the CPU architecture. For MIPS, the result is the same for little and big endian (it is always "mips" or "mips64" which is considered big endian). We need to distinguish between mips/mipsel and mips64/mips64el in order to install correct packages.