### PR TITLE
Add support for retrieving Group tag from package

### DIFF
--- a/src/package.c
+++ b/src/package.c
@@ -299,6 +299,12 @@ hy_package_get_evr(HyPackage pkg)
 }
 
 const char *
+hy_package_get_group(HyPackage pkg)
+{
+    return solvable_lookup_str(get_solvable(pkg), SOLVABLE_GROUP);
+}
+
+const char *
 hy_package_get_license(HyPackage pkg)
 {
     return solvable_lookup_str(get_solvable(pkg), SOLVABLE_LICENSE);

--- a/src/package.h
+++ b/src/package.h
@@ -60,6 +60,7 @@ const char *hy_package_get_arch(HyPackage pkg);
 const unsigned char *hy_package_get_chksum(HyPackage pkg, int *type);
 const char *hy_package_get_description(HyPackage pkg);
 const char *hy_package_get_evr(HyPackage pkg);
+const char *hy_package_get_group(HyPackage pkg);
 const char *hy_package_get_license(HyPackage pkg);
 const unsigned char *hy_package_get_hdr_chksum(HyPackage pkg, int *type);
 const char *hy_package_get_packager(HyPackage pkg);

--- a/src/python/package-py.c
+++ b/src/python/package-py.c
@@ -302,6 +302,7 @@ static PyGetSetDef package_getsetters[] = {
     {"description", (getter)get_str, NULL, NULL,
      (void *)hy_package_get_description},
     {"evr",  (getter)get_str, NULL, NULL, (void *)hy_package_get_evr},
+    {"group", (getter)get_str, NULL, NULL, (void *)hy_package_get_group},
     {"license", (getter)get_str, NULL, NULL, (void *)hy_package_get_license},
     {"packager",  (getter)get_str, NULL, NULL, (void *)hy_package_get_packager},
     {"reponame",  (getter)get_str, NULL, NULL, (void *)hy_package_get_reponame},


### PR DESCRIPTION
In Mageia (and some other distributions), the Group tag serves a purpose: categorizing what kind of packages they are. This pull request exposes that information from the package data.