### PR TITLE
build: don't set default build type and define _GNU_SOURCE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,13 @@ CMAKE_POLICY (SET CMP0005 OLD)
 INCLUDE (${CMAKE_SOURCE_DIR}/VERSION.cmake)
 SET (VERSION "${HAWKEY_MAJOR}.${HAWKEY_MINOR}.${HAWKEY_PATCH}")
 
-set (CMAKE_C_FLAGS		"${CMAKE_C_FLAGS} -std=c99 -Werror=implicit-function-declaration -Wall -Wl,--as-needed")
-set (CMAKE_C_FLAGS_DEBUG	"${CMAKE_C_FLAGS} -ggdb -O0")
-IF(NOT CMAKE_BUILD_TYPE)
-  set (CMAKE_BUILD_TYPE DEBUG)
-ENDIF(NOT CMAKE_BUILD_TYPE)
+include (CheckSymbolExists)
+list (APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+check_symbol_exists (FNM_CASEFOLD "fnmatch.h" HAS_FNM_CASEFOLD)
+if (NOT HAS_FNM_CASEFOLD)
+  message (SEND_ERROR "FNM_CASEFOLD is not available")
+endif ()
+add_definitions (-D_GNU_SOURCE)
 
 INCLUDE_DIRECTORIES (${CMAKE_SOURCE_DIR})
 


### PR DESCRIPTION
We will let CMake handle default build type. Also remove all custom
CFLAGS and use system ones.

References: https://bugzilla.redhat.com/show_bug.cgi?id=1332067
Signed-off-by: Igor Gnatenko i.gnatenko.brain@gmail.com
