### PR TITLE
util: detect rpm architecture prior than machine arch

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -116,9 +116,35 @@ hy_chksum_str(const unsigned char *chksum, int type)
 #define MAX_ARCH_LENGTH 64
 
 int
+hy_detect_rpm_arch(char *arch)
+{
+    FILE *fp = fopen("/etc/rpm/platform", "r");
+    int ret = HY_E_FAILED;
+
+    if (fp) {
+	if (fgets(arch, MAX_ARCH_LENGTH, fp)) {
+            char *pos = index(arch, '-');
+	    if (pos) {
+                *pos = 0;
+		ret = 0;
+	    }
+	}
+	fclose(fp);
+    }
+
+    return ret;
+}
+
+int
 hy_detect_arch(char **arch)
 {
     struct utsname un;
+    char rpm_arch[MAX_ARCH_LENGTH];
+
+    if (!hy_detect_rpm_arch(rpm_arch)) {
+	*arch = solv_strdup(rpm_arch);
+	return 0;
+    }
 
     if (uname(&un))
 	return HY_E_FAILED;


### PR DESCRIPTION
This patch implements to detect rpm architecture from
/etc/rpm/platform file. The file contains current rpm
platform architecture like "armv7hl-fedora-linux-gnu".
Originally, the file can be used to detect an arch
by rpm and yum command can also detect the architecture
through the file. Since the dnf is the default of fedora,
we can't use the file anymore.
When we want to use armv7hl platform on aarch64 kernel,
we can't use dnf command properly because the hawkey
detects the architecture by /proc/cpuinfo.

Signed-off-by: Chanho Park <chanho61.park@samsung.com>