### PR TITLE
Add file provides into pool for .rpm (RhBug:1263888)

### DIFF
--- a/src/goal.c
+++ b/src/goal.c
@@ -240,7 +240,6 @@ solve(HyGoal goal, Queue *job, int flags, hy_solution_callback user_cb,
     /* apply the excludes */
     sack_recompute_considered(sack);
 
-    repo_internalize_all_trigger(sack_pool(sack));
     sack_make_provides_ready(sack);
     if (goal->trans) {
 	transaction_free(goal->trans);

--- a/src/sack.c
+++ b/src/sack.c
@@ -1148,6 +1148,7 @@ void
 sack_make_provides_ready(HySack sack)
 {
     if (!sack->provides_ready) {
+    repo_internalize_all_trigger(sack_pool(sack));
 	Queue addedfileprovides;
 	Queue addedfileprovides_inst;
 	queue_init(&addedfileprovides);


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1263888

repo_internalize_all_trigger() unfolds package metadata from repos into pool
structures.

Moving it inside dnf_sack_make_provides_ready() to make sure it was called
before we start adding file provides.